### PR TITLE
Remove the 461 target

### DIFF
--- a/CoinbasePro/CoinbasePro.csproj
+++ b/CoinbasePro/CoinbasePro.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/dougdellolio/coinbasepro-csharp</RepositoryUrl>
     <Authors>Doug Dellolio</Authors>
@@ -23,10 +23,6 @@
     <PackageReference Include="WebSocket4Net" Version="0.15.2" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
-
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>


### PR DESCRIPTION
If you use the repo as submodule and try to use travis, it will fail cause the proyect target is .Net Framework 4.6.1 also and travis doesn't support it. Net Standard also target 461 so it is redundant but it crash travis compilations.
With this little change, the proyect can be builded in all platforms.