### PR TITLE
[Feature] Bump Newtonsoft for exponent fix

### DIFF
--- a/CoinbasePro.Specs/CoinbasePro.Specs.csproj
+++ b/CoinbasePro.Specs/CoinbasePro.Specs.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.7.0" />
     <PackageReference Include="Machine.Specifications.Should" Version="0.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.0.3" />
     <PackageReference Include="WebSocket4Net" Version="0.15.2" />
   </ItemGroup>

--- a/CoinbasePro.Specs/JsonFixtures/Websocket/WebSocketTypeResponseFixture.cs
+++ b/CoinbasePro.Specs/JsonFixtures/Websocket/WebSocketTypeResponseFixture.cs
@@ -13,6 +13,17 @@
 }";
         }
 
+        public static string CreateSnapshotResponseWithScientificNotation()
+        {
+            return @"
+{
+    ""type"": ""snapshot"",
+    ""product_id"": ""BTC-EUR"",
+    ""bids"": [[""1e-7"", ""2""]],
+    ""asks"": [[""2"", ""3""]]
+}";
+        }
+
         public static string CreateSubscriptionResponse()
         {
             return @"

--- a/CoinbasePro.Specs/WebSocket/WebSocketSpecs.cs
+++ b/CoinbasePro.Specs/WebSocket/WebSocketSpecs.cs
@@ -14,6 +14,7 @@ using Serilog;
 using Serilog.Sinks.TestCorrelator;
 using WebSocket4Net;
 using It = Machine.Specifications.It;
+using Match = CoinbasePro.WebSocket.Models.Response.Match;
 
 namespace CoinbasePro.Specs.WebSocket
 {
@@ -296,6 +297,19 @@ namespace CoinbasePro.Specs.WebSocket
                             WasToldTo(p => p.Invoke(Param.IsAny<EventHandler<WebfeedEventArgs<Done>>>(), Param.IsAny<object>(), Param.IsAny<WebfeedEventArgs<Done>>()));
                 }
 
+                class when_response_type_is_match
+                {
+                    Because of = () =>
+                    {
+                        Subject.Start(product_type_inputs, no_channel_type_inputs);
+                        websocket_feed.Raise(e => e.MessageReceived += null, new MessageReceivedEventArgs(WebSocketTypeResponseFixture.CreateMatchResponse()));
+                    };
+
+                    It should_have_invoked_match_response = () =>
+                        The<IWebSocketFeed>().
+                            WasToldTo(p => p.Invoke(Param.IsAny<EventHandler<WebfeedEventArgs<Match>>>(), Param.IsAny<object>(), Param.IsAny<WebfeedEventArgs<Match>>()));
+                }
+
                 class when_response_type_is_change
                 {
                     class with_size
@@ -357,6 +371,19 @@ namespace CoinbasePro.Specs.WebSocket
                     It should_not_have_called_invoke = () =>
                         The<IWebSocketFeed>().
                             WasNotToldTo(p => p.Invoke(Param.IsAny<EventHandler<WebfeedEventArgs<BaseMessage>>>(), Param.IsAny<object>(), Param.IsAny<WebfeedEventArgs<BaseMessage>>()));
+                }
+
+                class when_response_contains_scientific_notation
+                {
+                    Because of = () =>
+                    {
+                        Subject.Start(product_type_inputs, no_channel_type_inputs);
+                        websocket_feed.Raise(e => e.MessageReceived += null, new MessageReceivedEventArgs(WebSocketTypeResponseFixture.CreateSnapshotResponseWithScientificNotation()));
+                    };
+
+                    It should_return_a_response = () =>
+                        The<IWebSocketFeed>().
+                            WasToldTo(p => p.Invoke(Param.IsAny<EventHandler<WebfeedEventArgs<Snapshot>>>(), Param.IsAny<object>(), Param.IsAny<WebfeedEventArgs<Snapshot>>()));
                 }
             }
         }

--- a/CoinbasePro/CoinbasePro.csproj
+++ b/CoinbasePro/CoinbasePro.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.3.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="WebSocket4Net" Version="0.15.2" />
   </ItemGroup>


### PR DESCRIPTION
There is a new version of Newtonsoft (https://github.com/JamesNK/Newtonsoft.Json/releases/tag/12.0.1)  which fixes the parsing issues for https://github.com/dougdellolio/coinbasepro-csharp/issues/175 and https://github.com/dougdellolio/coinbasepro-csharp/issues/160

This bumps the package and also adds a test to ensure that it can deserialize properly