### PR TITLE
[Feature] Add new ZEC currency and product type

### DIFF
--- a/CoinbasePro/Shared/Types/Currency.cs
+++ b/CoinbasePro/Shared/Types/Currency.cs
@@ -13,6 +13,7 @@
         ETC,
         ZRX,
         USDC,
-        BAT
+        BAT,
+        ZEC
     }
 }

--- a/CoinbasePro/Shared/Types/ProductType.cs
+++ b/CoinbasePro/Shared/Types/ProductType.cs
@@ -55,6 +55,8 @@ namespace CoinbasePro.Shared.Types
         [EnumMember(Value = "ZRX-BTC")]
         ZrxBtc,
         [EnumMember(Value = "BAT-USDC")]
-        BatUsdc
+        BatUsdc,
+        [EnumMember(Value = "ZEC-USDC")]
+        ZecUsdc
     }
 }


### PR DESCRIPTION
Zcash is launching on Coinbase Pro https://blog.coinbase.com/zcash-zec-is-launching-on-coinbase-pro-b925309ce09c