### PR TITLE
[Bug] Fix possible null exception when calling websocket stop

### DIFF
--- a/CoinbasePro/Network/Authentication/Authenticator.cs
+++ b/CoinbasePro/Network/Authentication/Authenticator.cs
@@ -13,6 +13,13 @@ namespace CoinbasePro.Network.Authentication
             string unsignedSignature,
             string passphrase)
         {
+            if (string.IsNullOrEmpty(apiKey) || string.IsNullOrEmpty(unsignedSignature) ||
+                string.IsNullOrEmpty(passphrase))
+            {
+                throw new ArgumentException(
+                    $"{nameof(Authenticator)} requires parameters {nameof(apiKey)}, {nameof(unsignedSignature)} and {nameof(passphrase)} to be populated.");
+            }
+
             ApiKey = apiKey;
             UnsignedSignature = unsignedSignature;
             Passphrase = passphrase;

--- a/CoinbasePro/Services/Products/ProductsService.cs
+++ b/CoinbasePro/Services/Products/ProductsService.cs
@@ -89,7 +89,12 @@ namespace CoinbasePro.Services.Products
 
                 candleList.AddRange(await GetHistoricRatesAsync(productPair, batchStart, batchEnd.Value, (int)granularity));
 
+                var previousBatchEnd = batchEnd;
                 batchEnd = candleList.LastOrDefault()?.Time;
+
+                if (previousBatchEnd == batchEnd) {
+                    break;
+                }
 
             } while (batchStart > start);
 

--- a/CoinbasePro/WebSocket/WebSocket.cs
+++ b/CoinbasePro/WebSocket/WebSocket.cs
@@ -36,7 +36,7 @@ namespace CoinbasePro.WebSocket
 
         private IWebSocketFeed webSocketFeed;
 
-        public WebSocketState State => webSocketFeed.State;
+        public WebSocketState State => webSocketFeed?.State ?? WebSocketState.None;
 
         public WebSocket(
             Func<IWebSocketFeed> createWebSocketFeed,
@@ -92,6 +92,12 @@ namespace CoinbasePro.WebSocket
 
         public void Stop()
         {
+            if (webSocketFeed == null)
+            {
+                Log.Information("WebSocket stopped with no inner webSocketFeed");
+                return;
+            }
+
             if (webSocketFeed.State != WebSocketState.Open)
             {
                 throw new CoinbaseProWebSocketException(

--- a/CoinbasePro/WebSocket/WebSocket.cs
+++ b/CoinbasePro/WebSocket/WebSocket.cs
@@ -94,7 +94,7 @@ namespace CoinbasePro.WebSocket
         {
             if (webSocketFeed == null)
             {
-                Log.Information("WebSocket stopped with no inner webSocketFeed");
+                Log.Warning("Websocket did not attempt to stop as the feed has not been started yet");
                 return;
             }
 


### PR DESCRIPTION
Bug fix for #190 

There is also a change that corrects an issue that can occur in the historic candles area - when pulling very old data it's possible to get into an infinite loop where it keeps pulling the oldest candles over and over.