### PR TITLE
[Feature] Change ProductId on Websocket Ticker from String to ProductType

### DIFF
--- a/CoinbasePro/WebSocket/Models/Response/Ticker.cs
+++ b/CoinbasePro/WebSocket/Models/Response/Ticker.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using CoinbasePro.Services.Orders.Types;
+using CoinbasePro.Shared.Types;
 
 namespace CoinbasePro.WebSocket.Models.Response
 {
@@ -8,7 +9,7 @@ namespace CoinbasePro.WebSocket.Models.Response
     {
         public long Sequence { get; set; }
 
-        public string ProductId { get; set; }
+        public ProductType ProductId { get; set; }
 
         public decimal Price { get; set; }
 


### PR DESCRIPTION
… ProductType enum.

Minor change and tested locally.

Hope it helps, please disregard if this change is unwanted.