### PR TITLE
[Feature] Add support for missing currencies and product types

### DIFF
--- a/CoinbasePro/Shared/Types/Currency.cs
+++ b/CoinbasePro/Shared/Types/Currency.cs
@@ -27,6 +27,8 @@
         XTZ,
         ZEC,
         ZIL,
-        ZRX
+        ZRX,
+        ALGO,
+        LINK,
     }
 }

--- a/CoinbasePro/Shared/Types/ProductType.cs
+++ b/CoinbasePro/Shared/Types/ProductType.cs
@@ -104,5 +104,17 @@ namespace CoinbasePro.Shared.Types
         RepEur,
         [EnumMember(Value = "REP-BTC")]
         RepBtc,
+        [EnumMember(Value = "ALGO-USD")]
+        AlgoUsd,
+        [EnumMember(Value = "BAT-ETH")]
+        BatEth,
+        [EnumMember(Value = "ETH-DAI")]
+        EthDai,
+        [EnumMember(Value = "LINK-ETH")]
+        LinkEth,
+        [EnumMember(Value = "LINK-USD")]
+        LinkUsd,
+        [EnumMember(Value = "ZEC-BTC")]
+        ZecBtc,
     }
 }


### PR DESCRIPTION
Currencies: Algorand (ALGO), Chainlink (LINK)
Product types: AlgoUsd, BatEth, EthDai, LinkEth, LinkUsd

Based on api methods: https://docs.pro.coinbase.com/#get-currencies and https://docs.pro.coinbase.com/#get-products