### PR TITLE
[Bug] Fix GetCurrentFees now returning a single Fee object

### DIFF
--- a/CoinbasePro.Specs/JsonFixtures/Services/Fees/FeesResponseFixture.cs
+++ b/CoinbasePro.Specs/JsonFixtures/Services/Fees/FeesResponseFixture.cs
@@ -5,13 +5,11 @@
         public static string Create()
         {
             var json = @"
-[
-    {
-        ""maker_fee_rate"": ""0.0015"",
-        ""taker_fee_rate"": ""0.0025"",
-        ""usd_volume"": ""25000.00""
-    }
-]";
+{
+    ""maker_fee_rate"": ""0.0015"",
+    ""taker_fee_rate"": ""0.0025"",
+    ""usd_volume"": ""25000.00""
+}";
 
             return json;
         }

--- a/CoinbasePro.Specs/Services/Fees/FeesServiceSpecs.cs
+++ b/CoinbasePro.Specs/Services/Fees/FeesServiceSpecs.cs
@@ -21,7 +21,7 @@ namespace CoinbasePro.Specs.Services.Fees
 
         class when_getting_current_fees
         {
-            static IEnumerable<Fee> fee_response;
+            static Fee fee_response;
 
             Establish context = () =>
                 The<IHttpClient>().WhenToldTo(p => p.ReadAsStringAsync(Param.IsAny<HttpResponseMessage>()))
@@ -35,9 +35,9 @@ namespace CoinbasePro.Specs.Services.Fees
 
             It should_return_a_correct_response = () =>
             {
-                fee_response.First().MakerFeeRate.ShouldEqual(0.0015m);
-                fee_response.First().TakerFeeRate.ShouldEqual(0.0025m);
-                fee_response.First().UsdVolume.ShouldEqual(25000);
+                fee_response.MakerFeeRate.ShouldEqual(0.0015m);
+                fee_response.TakerFeeRate.ShouldEqual(0.0025m);
+                fee_response.UsdVolume.ShouldEqual(25000);
             };
         }
     }

--- a/CoinbasePro/Services/Fees/FeesService.cs
+++ b/CoinbasePro/Services/Fees/FeesService.cs
@@ -16,9 +16,9 @@ namespace CoinbasePro.Services.Fees
         {
         }
 
-        public async Task<IEnumerable<Fee>> GetCurrentFeesAsync()
+        public async Task<Fee> GetCurrentFeesAsync()
         {
-            var fees = await SendServiceCall<IEnumerable<Fee>>(HttpMethod.Get, "/fees");
+            var fees = await SendServiceCall<Fee>(HttpMethod.Get, "/fees");
 
             return fees;
         }

--- a/CoinbasePro/Services/Fees/IFeesService.cs
+++ b/CoinbasePro/Services/Fees/IFeesService.cs
@@ -6,6 +6,6 @@ namespace CoinbasePro.Services.Fees
 {
     public interface IFeesService
     {
-        Task<IEnumerable<Fee>> GetCurrentFeesAsync();
+        Task<Fee> GetCurrentFeesAsync();
     }
 }


### PR DESCRIPTION
GetCurrentFees now returns only the current fees instead of all fee tiers.