### PR TITLE
Added coinbase supported fields to product type.

### DIFF
--- a/CoinbasePro.Specs/JsonFixtures/Services/Products/ProductsResponseFixture.cs
+++ b/CoinbasePro.Specs/JsonFixtures/Services/Products/ProductsResponseFixture.cs
@@ -10,9 +10,18 @@
         'id': 'BTC-USD',
         'base_currency': 'BTC',
         'quote_currency': 'USD',
+        'base_increment': '0.00000001',
+        'quote_increment': '0.01',
         'base_min_size': '0.01',
         'base_max_size': '10000.00',
-        'quote_increment': '0.01'
+        'min_market_funds': '5',
+        'max_market_funds': '1000000',
+        'status': 'online',
+        'status_message': '',
+        'cancel_only': 'false',
+        'limit_only': 'false',
+        'post_only': 'true',
+        'trading_disabled': 'false',
     }
 ]";
 

--- a/CoinbasePro.Specs/Services/Products/ProductsServiceSpecs.cs
+++ b/CoinbasePro.Specs/Services/Products/ProductsServiceSpecs.cs
@@ -59,6 +59,15 @@ namespace CoinbasePro.Specs.Services.Products
                     products_result.First().BaseMinSize.ShouldEqual(0.01M);
                     products_result.First().BaseMaxSize.ShouldEqual(10000.00M);
                     products_result.First().QuoteIncrement.ShouldEqual(0.01M);
+                    products_result.First().MinMarketFunds.ShouldEqual(5M);
+                    products_result.First().MaxMarketFunds.ShouldEqual(1000000M);
+                    products_result.First().BaseIncrement.ShouldEqual(0.00000001M);
+                    products_result.First().PostOnly.ShouldEqual(true);
+                    products_result.First().LimitOnly.ShouldEqual(false);
+                    products_result.First().CancelOnly.ShouldEqual(false);
+                    products_result.First().TradingDisabled.ShouldEqual(false);
+                    products_result.First().Status.ShouldEqual("online");
+                    products_result.First().StatusMessage.ShouldBeEmpty();
                 };
             }
 
@@ -225,7 +234,7 @@ namespace CoinbasePro.Specs.Services.Products
 
             Because of = () =>
                 product_history_response = Subject.GetHistoricRatesAsync(ProductType.BtcUsd, DateTime.Now.AddDays(-1), DateTime.Now, CandleGranularity.Minutes1).Result;
-            
+
             It should_have_correct_product_stats = () =>
             {
                 product_history_response[0].Time.ShouldEqual(UnixEpoch.AddSeconds(1512691200));

--- a/CoinbasePro/Services/Products/Models/Product.cs
+++ b/CoinbasePro/Services/Products/Models/Product.cs
@@ -19,6 +19,24 @@ namespace CoinbasePro.Services.Products.Models
 
         public decimal BaseMaxSize { get; set; }
 
+        public decimal MinMarketFunds { get; set; }
+
+        public decimal MaxMarketFunds { get; set; }
+
         public decimal QuoteIncrement { get; set; }
+
+        public decimal BaseIncrement { get; set; }
+
+        public bool PostOnly { get; set; }
+
+        public bool LimitOnly { get; set; }
+
+        public bool CancelOnly { get; set; }
+
+        public bool TradingDisabled { get; set; }
+
+        public string Status { get; set; }
+
+        public string StatusMessage { get; set; }
     }
 }


### PR DESCRIPTION
Added all fields to the 'Product', which are supported for "Get Products" by coinbase pro.

(https://docs.pro.coinbase.com/#products).

 {
        "id": "BTC-USD",
        "display_name": "BTC/USD",
        "base_currency": "BTC",
        "quote_currency": "USD",
        "base_increment": "0.00000001",
        "quote_increment": "0.01000000",
        "base_min_size": "0.00100000",
        "base_max_size": "280.00000000",
        "min_market_funds": "5",
        "max_market_funds": "1000000",
        "status": "online",
        "status_message": "",
        "cancel_only": false,
        "limit_only": false,
        "post_only": false,
        "trading_disabled": false
    }