### PR TITLE
Add support to LINK-USDC

### DIFF
--- a/CoinbasePro/Shared/Types/ProductType.cs
+++ b/CoinbasePro/Shared/Types/ProductType.cs
@@ -141,6 +141,8 @@ namespace CoinbasePro.Shared.Types
         [EnumMember(Value = "COMP-BTC")]
         CompBtc,
         [EnumMember(Value = "COMP-USD")]
-        CompUsd
+        CompUsd,
+        [EnumMember(Value="LINK-USDC")]
+        LinkUsdc
     }
 }


### PR DESCRIPTION
The sandbox instead of supporting `LINK-USD` it supports `LINK-USDC`.

This pull request solves the error: 

```bash
The response value LINK-USDC cannot be mapped to the enum type CoinbasePro.Shared.Types.ProductType.
```