### PR TITLE
Add try/catch for TaskCanceledException

### DIFF
--- a/CoinbasePro/Network/HttpClient/HttpClient.cs
+++ b/CoinbasePro/Network/HttpClient/HttpClient.cs
@@ -17,8 +17,15 @@ namespace CoinbasePro.Network.HttpClient
             HttpRequestMessage httpRequestMessage,
             CancellationToken cancellationToken)
         {
-                var result = await Client.SendAsync(httpRequestMessage, cancellationToken);
-                return result;
+                try
+                {
+                    var result = await Client.SendAsync(httpRequestMessage, cancellationToken);
+                    return result;
+                }
+                catch (TaskCanceledException)
+                {
+                    throw;
+                }
         }
 
         public async Task<string> ReadAsStringAsync(HttpResponseMessage httpRequestMessage)


### PR DESCRIPTION
When sending a cancellation token, wrap the request in a try-catch.
From the link below:
"System.Net.Http.HttpClientHandler handles the inner exception (as it is supposed to), and lets cancellation and cleanup continue for the task. This ultimately calls into the app’s task, where the second (outer) exception occurs because the app’s task is not catching the System.Threading.Tasks.TaskCanceledException exception. The outer exception fails in mscorlib_ni!System.Runtime.CompilerServices.TaskAwaiter.ValidateEndwhen checking to see if the task is wait-notification enabled, or if it has not been run to completion. If the app implements a handler for System.Threading.Tasks.TaskCanceledException, execution would actually never reach this code."
https://blogs.windows.com/windowsdeveloper/2014/05/23/understanding-and-resolving-app-crashes-and-failures-in-windows-store-apps-part-2-json-and-tiles/